### PR TITLE
ENH: add support for LinkedSequence as input

### DIFF
--- a/q2_kmerizer/_methods.py
+++ b/q2_kmerizer/_methods.py
@@ -41,7 +41,7 @@ def seqs_to_kmers(sequences: pd.Series, table: pd.DataFrame,
     # analyzer is changed to char_wb to accommodate linked sequences
     # i.e., so that kmers do not bridge gaps between sequences.
     # This will, however, yield terminal kmers that contain one space.
-    # Functionally speaking this probably does not matter during 
+    # Functionally speaking this probably does not matter during
     # tokenization and the same terminal kmers are likely to be found in
     # many sequences.
     if tfidf:

--- a/q2_kmerizer/_methods.py
+++ b/q2_kmerizer/_methods.py
@@ -38,15 +38,21 @@ def seqs_to_kmers(sequences: pd.Series, table: pd.DataFrame,
         raise ValueError('No feature IDs match between the inputs.')
 
     # vectorize
+    # analyzer is changed to char_wb to accommodate linked sequences
+    # i.e., so that kmers do not bridge gaps between sequences.
+    # This will, however, yield terminal kmers that contain one space.
+    # Functionally speaking this probably does not matter during 
+    # tokenization and the same terminal kmers are likely to be found in
+    # many sequences.
     if tfidf:
         _vectorizer = TfidfVectorizer
         cv = _vectorizer(
-            ngram_range=ngram_range, analyzer='char', lowercase=False,
+            ngram_range=ngram_range, analyzer='char_wb', lowercase=False,
             max_df=max_df, min_df=min_df, max_features=max_features, norm=norm)
     else:
         _vectorizer = CountVectorizer
         cv = _vectorizer(
-            ngram_range=ngram_range, analyzer='char', lowercase=False,
+            ngram_range=ngram_range, analyzer='char_wb', lowercase=False,
             max_df=max_df, min_df=min_df, max_features=max_features)
     # derive table of kmer frequencies per sequence
     X = cv.fit_transform(sequences.apply(str).values.tolist())

--- a/q2_kmerizer/plugin_setup.py
+++ b/q2_kmerizer/plugin_setup.py
@@ -12,7 +12,7 @@ from q2_kmerizer import __version__
 from qiime2.plugin import (Int, Float, Bool, Range, Visualization, Metadata,
                            Str, Choices)
 from q2_types.feature_data import (
-    FeatureData, Sequence, RNASequence, ProteinSequence)
+    FeatureData, Sequence, RNASequence, ProteinSequence, LinkedSequence)
 from q2_types.distance_matrix import DistanceMatrix
 from q2_types.sample_data import AlphaDiversity, SampleData
 from q2_types.ordination import PCoAResults
@@ -40,7 +40,8 @@ n_jobs_description = (
 )
 
 inputs = {
-    'sequences': FeatureData[Sequence | RNASequence | ProteinSequence],
+    'sequences': FeatureData[
+        Sequence | RNASequence | ProteinSequence | LinkedSequence],
     'table': FeatureTable[Frequency]}
 
 core_parameters = {

--- a/q2_kmerizer/tests/test_methods.py
+++ b/q2_kmerizer/tests/test_methods.py
@@ -30,20 +30,22 @@ class KmerizerTests(TestPluginBase):
         observed = seqs_to_kmers(self.seqs, self.table, kmer_size=7)
 
         expected = pd.DataFrame(
-            [[1, 0, 0, 1, 0, 0, 1, 0, 1, 0, 1, 0, 0, 1, 1, 1, 1, 1, 0, 1, 0, 1,
-              0, 0, 1, 0, 1, 0],
-             [2, 3, 3, 2, 3, 3, 2, 3, 2, 3, 2, 3, 3, 2, 2, 2, 2, 2, 3, 2, 3, 2,
-              3, 3, 2, 3, 2, 3],
-             [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-              1, 1, 1, 1, 1, 1]],
-            columns=['AAGCGTT', 'AAGGGTT', 'ACGAGAA', 'ACGGGAG', 'AGAAGGG',
-                     'AGCGTTA', 'AGGGTGC', 'AGGGTTA', 'CAAGCGT', 'CGAGAAG',
-                     'CGGGAGG', 'GAAGGGT', 'GAGAAGG', 'GAGGGTG', 'GCAAGCG',
-                     'GGAGGGT', 'GGGAGGG', 'GGGTGCA', 'GGGTTAG', 'GGTGCAA',
-                     'GGTTAGC', 'GTGCAAG', 'GTTAGCG', 'TACGAGA', 'TACGGGA',
-                     'TAGCGTT', 'TGCAAGC', 'TTAGCGT'],
+            [[0., 1., 1., 0., 0., 1., 0., 1., 0., 1., 0., 1., 0., 1., 0., 0.,
+              1., 1., 0., 1., 1., 1., 0., 1., 0., 1., 0., 0., 1., 0., 1., 0.],
+             [3., 2., 2., 3., 3., 2., 3., 2., 3., 2., 3., 2., 3., 2., 3., 3.,
+              2., 2., 3., 2., 2., 2., 3., 2., 3., 2., 3., 3., 2., 3., 2., 3.],
+             [1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1.,
+              1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1.]],
+            columns=[' TACGAG', ' TACGGG', 'AAGCGTT', 'AAGGGTT', 'ACGAGAA',
+                     'ACGGGAG', 'AGAAGGG', 'AGCGTT ', 'AGCGTTA', 'AGGGTGC',
+                     'AGGGTTA', 'CAAGCGT', 'CGAGAAG', 'CGGGAGG', 'GAAGGGT',
+                     'GAGAAGG', 'GAGGGTG', 'GCAAGCG', 'GCGTTA ', 'GGAGGGT',
+                     'GGGAGGG', 'GGGTGCA', 'GGGTTAG', 'GGTGCAA', 'GGTTAGC',
+                     'GTGCAAG', 'GTTAGCG', 'TACGAGA', 'TACGGGA', 'TAGCGTT',
+                     'TGCAAGC', 'TTAGCGT'],
             index=['s1', 's2', 's3'])
-        print(observed.to_dataframe().T)
+        print(observed.to_dataframe().T.to_numpy())
+        print(observed.to_dataframe().index)
 
         # note: observed df is transposed because it is transposed by biom
         pdt.assert_frame_equal(observed.to_dataframe().T, expected,
@@ -54,31 +56,36 @@ class KmerizerTests(TestPluginBase):
             self.seqs, self.table, tfidf=True, kmer_size=7)
 
         expected = pd.DataFrame(
-            [[1.405465, 0., 0., 1.405465, 0.,
-              0., 1.405465, 0., 1.405465, 0.,
-              1.405465, 0., 0., 1.405465, 1.405465,
-              1.405465, 1.405465, 1.405465, 0., 1.405465,
-              0., 1.405465, 0., 0., 1.405465,
-              0., 1.405465, 0.],
-             [2.81093, 4.216395, 4.216395, 2.81093, 4.216395,
-              4.216395, 2.81093, 4.216395, 2.81093, 4.216395,
-              2.81093, 4.216395, 4.216395, 2.81093, 2.81093,
-              2.81093, 2.81093, 2.81093, 4.216395, 2.81093,
-              4.216395, 2.81093, 4.216395, 4.216395, 2.81093,
-              4.216395, 2.81093, 4.216395],
-             [1.405465, 1.405465, 1.405465, 1.405465, 1.405465,
-              1.405465, 1.405465, 1.405465, 1.405465, 1.405465,
-              1.405465, 1.405465, 1.405465, 1.405465, 1.405465,
-              1.405465, 1.405465, 1.405465, 1.405465, 1.405465,
-              1.405465, 1.405465, 1.405465, 1.405465, 1.405465,
-              1.405465, 1.405465, 1.405465]],
-            columns=['AAGCGTT', 'AAGGGTT', 'ACGAGAA', 'ACGGGAG', 'AGAAGGG',
-                     'AGCGTTA', 'AGGGTGC', 'AGGGTTA', 'CAAGCGT', 'CGAGAAG',
-                     'CGGGAGG', 'GAAGGGT', 'GAGAAGG', 'GAGGGTG', 'GCAAGCG',
-                     'GGAGGGT', 'GGGAGGG', 'GGGTGCA', 'GGGTTAG', 'GGTGCAA',
-                     'GGTTAGC', 'GTGCAAG', 'GTTAGCG', 'TACGAGA', 'TACGGGA',
-                     'TAGCGTT', 'TGCAAGC', 'TTAGCGT'],
+            [[0., 1.40546511, 1.40546511, 0., 0., 1.40546511, 0., 1.40546511,
+              0., 1.40546511, 0., 1.40546511, 0., 1.40546511, 0., 0.,
+              1.40546511, 1.40546511, 0., 1.40546511, 1.40546511, 1.40546511,
+              0., 1.40546511, 0., 1.40546511, 0., 0., 1.40546511, 0.,
+              1.40546511, 0.],
+             [4.21639532, 2.81093022, 2.81093022, 4.21639532, 4.21639532,
+              2.81093022, 4.21639532, 2.81093022, 4.21639532, 2.81093022,
+              4.21639532, 2.81093022, 4.21639532, 2.81093022, 4.21639532,
+              4.21639532, 2.81093022, 2.81093022, 4.21639532, 2.81093022,
+              2.81093022, 2.81093022, 4.21639532, 2.81093022, 4.21639532,
+              2.81093022, 4.21639532, 4.21639532, 2.81093022, 4.21639532,
+              2.81093022, 4.21639532],
+             [1.40546511, 1.40546511, 1.40546511, 1.40546511, 1.40546511,
+             1.40546511, 1.40546511, 1.40546511, 1.40546511, 1.40546511,
+             1.40546511, 1.40546511, 1.40546511, 1.40546511, 1.40546511,
+             1.40546511, 1.40546511, 1.40546511, 1.40546511, 1.40546511,
+             1.40546511, 1.40546511, 1.40546511, 1.40546511, 1.40546511,
+             1.40546511, 1.40546511, 1.40546511, 1.40546511, 1.40546511,
+             1.40546511, 1.40546511]],
+            columns=[' TACGAG', ' TACGGG', 'AAGCGTT', 'AAGGGTT', 'ACGAGAA',
+                     'ACGGGAG', 'AGAAGGG', 'AGCGTT ', 'AGCGTTA', 'AGGGTGC',
+                     'AGGGTTA', 'CAAGCGT', 'CGAGAAG', 'CGGGAGG', 'GAAGGGT',
+                     'GAGAAGG', 'GAGGGTG', 'GCAAGCG', 'GCGTTA ', 'GGAGGGT',
+                     'GGGAGGG', 'GGGTGCA', 'GGGTTAG', 'GGTGCAA', 'GGTTAGC',
+                     'GTGCAAG', 'GTTAGCG', 'TACGAGA', 'TACGGGA', 'TAGCGTT',
+                     'TGCAAGC', 'TTAGCGT'],
             index=['s1', 's2', 's3'])
+
+        print(observed.to_dataframe().T.to_numpy())
+        print(observed.to_dataframe().index)
 
         # note: observed df is transposed because it is transposed by biom
         pdt.assert_frame_equal(observed.to_dataframe().T, expected,

--- a/q2_kmerizer/tests/test_methods.py
+++ b/q2_kmerizer/tests/test_methods.py
@@ -44,8 +44,6 @@ class KmerizerTests(TestPluginBase):
                      'GTGCAAG', 'GTTAGCG', 'TACGAGA', 'TACGGGA', 'TAGCGTT',
                      'TGCAAGC', 'TTAGCGT'],
             index=['s1', 's2', 's3'])
-        print(observed.to_dataframe().T.to_numpy())
-        print(observed.to_dataframe().index)
 
         # note: observed df is transposed because it is transposed by biom
         pdt.assert_frame_equal(observed.to_dataframe().T, expected,
@@ -83,9 +81,6 @@ class KmerizerTests(TestPluginBase):
                      'GTGCAAG', 'GTTAGCG', 'TACGAGA', 'TACGGGA', 'TAGCGTT',
                      'TGCAAGC', 'TTAGCGT'],
             index=['s1', 's2', 's3'])
-
-        print(observed.to_dataframe().T.to_numpy())
-        print(observed.to_dataframe().index)
 
         # note: observed df is transposed because it is transposed by biom
         pdt.assert_frame_equal(observed.to_dataframe().T, expected,


### PR DESCRIPTION
Adds support for LinkedSequence as an input.

# Description
The tokenizer was switched from `char` to `char_wb` so that kmers do not bridge the space in any linked sequences ([see here](https://scikit-learn.org/stable/modules/generated/sklearn.feature_extraction.text.TfidfVectorizer.html) for a parameter explanation). However, this means that any input sequence will yield terminal kmers that contain spaces. Functionally speaking, this is unlikely to be a problem as they will not clash with other kmers, will be shared across many sequences, and are technically correct (the space is saying "the sequence stops here"). However, this means that the unit tests are adjusted in this PR to include those additional terminal kmers. 

# AI Disclosure
<!-- REQUIRED: Check exactly one option. -->

- [X] NO AI USED.
- [ ] AI USED.
